### PR TITLE
feat(classifier): Scaffold RuleLoader and TransactionClassifier classes

### DIFF
--- a/src/classify.py
+++ b/src/classify.py
@@ -1,0 +1,77 @@
+import re
+
+# Operator functions
+OPERATORS = {
+    "CONTAINS": lambda s, v: v.lower() in (s or "").lower(),
+    "STARTS_WITH": lambda s, v: (s or "").lower().startswith(v.lower()),
+    "EQUALS": lambda a, v: str(a).lower() == str(v).lower(),
+    "REGEX": lambda s, pattern: re.search(pattern, s or "") is not None,
+    "GREATER_THAN": lambda n, v: float(n) > float(v),
+    "GREATER_THAN_OR_EQUAL_TO": lambda n, v: float(n) >= float(v),
+    "LESS_THAN": lambda n, v: float(n) < float(v),
+    "LESS_THAN_OR_EQUAL_TO": lambda n, v: float(n) <= float(v),
+    "BETWEEN": lambda n, rng: float(rng[0]) <= float(n) <= float(rng[1]),
+}
+
+class TransactionClassifier:
+    """
+    Applies allocation_rules.json to classify transactions.
+    Evaluates rules in priority order until a match is found.
+    """
+
+    def __init__(self, rules: list):
+        self.rules = rules
+
+    def classify(self, transaction: dict) -> dict:
+        """
+        Classify a single transaction.
+        Returns a dict with category, transaction_type, and dual_entry mapping.
+        """
+        for rule in self.rules:
+            if self._evaluate_rule(rule, transaction):
+                return {
+                    "category": rule["category_name"],
+                    "transaction_type": rule["transaction_type"],
+                    "dual_entry": rule.get("dual_entry"),
+                }
+        # Default: manual review
+        return {
+            "category": "Unclassified",
+            "transaction_type": "MANUAL_CR" if transaction.get("Debit") else "MANUAL_DR",
+            "dual_entry": None,
+        }
+
+    def _evaluate_rule(self, rule: dict, transaction: dict) -> bool:
+        """Evaluate a rule against a transaction."""
+        logic = rule.get("logic", "MUST_MATCH_ANY")
+        conditions = rule.get("rules", [])
+
+        results = []
+        for cond in conditions:
+            if "group_logic" in cond:  # Nested group
+                group_results = [
+                    self._apply_operator(sub, transaction) for sub in cond["rules"]
+                ]
+                results.append(
+                    all(group_results) if cond["group_logic"] == "MUST_MATCH_ALL" else any(group_results)
+                )
+            else:
+                results.append(self._apply_operator(cond, transaction))
+
+        return all(results) if logic == "MUST_MATCH_ALL" else any(results)
+
+    def _apply_operator(self, cond: dict, transaction: dict) -> bool:
+        """Apply a single operator to a transaction field."""
+        field = cond["field"]
+        operator = cond["operator"]
+        value = cond["value"]
+        field_value = transaction.get(field)
+
+        func = OPERATORS.get(operator)
+        if not func:
+            raise ValueError(f"Unsupported operator: {operator}")
+
+        try:
+            return func(field_value, value)
+        except Exception:
+            return False

--- a/src/rules.py
+++ b/src/rules.py
@@ -1,0 +1,32 @@
+import json
+import os
+
+class RuleLoader:
+    """
+    Loads and validates allocation_rules.json.
+    Provides access to the ordered list of rules.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self.rules = []
+
+    def load(self) -> list:
+        """Load rules from JSON file and validate schema."""
+        if not os.path.exists(self.path):
+            raise FileNotFoundError(f"Rules file not found: {self.path}")
+
+        with open(self.path, "r") as f:
+            data = json.load(f)
+
+        if "_rules" not in data or not isinstance(data["_rules"], list):
+            raise ValueError("Invalid ruleset: missing '_rules' array")
+
+        self.rules = data["_rules"]
+        return self.rules
+
+    def get_rules(self) -> list:
+        """Return loaded rules."""
+        if not self.rules:
+            raise RuntimeError("Rules not loaded. Call load() first.")
+        return self.rules


### PR DESCRIPTION
This pull request introduces two new core modules to support rule-based transaction classification: one for loading and validating classification rules from a JSON file, and another for applying these rules to transactions using a flexible set of operators. These changes lay the groundwork for automated and configurable transaction categorization.

**Rule management and loading:**

* Added a `RuleLoader` class in `src/rules.py` to load and validate the `allocation_rules.json` file, ensuring the rules are present and correctly structured before use.

**Transaction classification logic:**

* Introduced a `TransactionClassifier` class in `src/classify.py` that applies loaded rules to transactions in priority order, supporting various logical groupings and defaulting to manual review if no rule matches.
* Implemented a comprehensive set of operator functions (e.g., `CONTAINS`, `EQUALS`, `REGEX`, and numeric comparisons) to enable flexible and robust rule conditions for transaction fields.
* Supported nested rule groups and both "match any" and "match all" logic for advanced rule evaluation within the classifier.