### PR TITLE
tests(rules): Add integration tests for allocation_rules.json against…

### DIFF
--- a/tests/test_rules_integration.py
+++ b/tests/test_rules_integration.py
@@ -1,0 +1,75 @@
+import pytest
+import os
+import json
+from src.rules import RuleLoader
+from src.classify import TransactionClassifier
+
+@pytest.fixture(scope="module")
+def ruleset():
+    """Load the real allocation_rules.json file."""
+    path = os.path.join("config", "allocation_rules.json")
+    loader = RuleLoader(path)
+    return loader.load()
+
+@pytest.fixture
+def classifier(ruleset):
+    """Instantiate classifier with real ruleset."""
+    return TransactionClassifier(ruleset)
+
+# --------------------------
+# Integration Tests
+# --------------------------
+
+def test_vehicle_insurance_rule(classifier):
+    tx = {"Description": "Economical Insurance Premium", "Debit": 200.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Vehicle Expenses - Insurance & Services"
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "L"
+    assert result["dual_entry"]["CR_COLUMN"]["letter"] == "F"
+
+def test_fido_bill_rule(classifier):
+    tx = {"Description": "FIDO Mobile Bill", "Debit": 75.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Telephone - Fido Bill"
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "N"
+
+def test_bank_fee_rule(classifier):
+    tx = {"Description": "MONTHLY ACCOUNT FEE", "Debit": 15.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Bank Fees - Monthly Account Fee"
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "P"
+
+def test_bank_rebate_rule(classifier):
+    tx = {"Description": "ACCT BAL REBATE", "Debit": "", "Credit": 5.00}
+    result = classifier.classify(tx)
+    assert result["category"] == "Bank Fees - Account Rebate"
+    assert result["dual_entry"]["APPLY_PERCENTAGE"] == -1.0
+
+def test_vehicle_fuel_range_rule(classifier):
+    tx = {"Description": "ESSO CIRCLE K", "Debit": 50.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Vehicle Expenses - Fuel (Range Based)"
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "L"
+
+def test_business_coffee_rule(classifier):
+    tx = {"Description": "TIM HORTONS #123", "Debit": 4.50, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Food/Drink Expenses - Business Meal or Coffee"
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "T"
+
+def test_client_gifts_rule(classifier):
+    tx = {"Description": "LCBO Purchase", "Debit": 60.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Client Gifts - Wine/Spirits/Restaurant/Gift Cards/Baked Goods/Etc."
+    assert result["dual_entry"]["DR_COLUMN"]["letter"] == "V"
+
+def test_ignore_internal_transfer(classifier):
+    tx = {"Description": "TRIANGLE MC PAYMENT", "Debit": 500.00, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["transaction_type"] == "IGNORE_TRANSACTION"
+
+def test_unclassified_fallback(classifier):
+    tx = {"Description": "UNKNOWN MERCHANT", "Debit": 123.45, "Credit": ""}
+    result = classifier.classify(tx)
+    assert result["category"] == "Unclassified"
+    assert result["dual_entry"] is None


### PR DESCRIPTION
This pull request adds a comprehensive suite of integration tests for the transaction classification logic, ensuring that real-world transaction descriptions are correctly categorized and handled as expected. The tests cover a variety of scenarios, including specific merchant rules, fee handling, and fallback behavior for unclassified transactions.

Integration tests for transaction classification:

* Added integration tests in `tests/test_rules_integration.py` to verify that the `TransactionClassifier` correctly classifies transactions using the real `allocation_rules.json` ruleset.
* Tests cover specific cases such as vehicle insurance, mobile bills, bank fees and rebates, fuel purchases, business meals, client gifts, internal transfers to be ignored, and fallback for unknown merchants.
* Utilizes pytest fixtures to load the ruleset and instantiate the classifier for use across tests.… sample transactions