### PR TITLE
feat(cli): Implement --no-progress flag for quiet, non-verbose script…

### DIFF
--- a/project.py
+++ b/project.py
@@ -62,14 +62,16 @@ def main():
     # Define the final output file path
     output_file = output_dir / f"bookkeeping_{args.year}.xlsx"
     
-    print(f"Starting pipeline for year {args.year}...")
-    print(f"Input files found: {len(input_files)}")
-    print(f"Transactions loaded: {len(transactions)}")
-    print(f"Rules loaded from: {args.rules}")
-    print(f"Output will be saved to: {output_file}")
+    # Conditionally show progress
+    if not args.no_progress:
+        print(f"Starting pipeline for year {args.year}...")
+        print(f"Input files found: {len(input_files)}")
+        print(f"Transactions loaded: {len(transactions)}")
+        print(f"Rules loaded from: {args.rules}")
+        print(f"Output will be saved to: {output_file}")
 
     # Run pipeline
-    wb = run_pipeline(transactions, args.rules)
+    wb = run_pipeline(transactions, args.rules, show_progress=(not args.no_progress))
     wb.save(output_file)
     
     print(f"\n✅ Success! Pipeline complete. File saved to {output_file}")
@@ -91,6 +93,11 @@ def get_cli_args() -> argparse.Namespace:
         type=Path,
         default=Path("config/allocation_rules.json"),
         help="Path to the JSON allocation rules file (default: config/allocation_rules.json)."
+    )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable progress bars and verbose status messages."
     )
     return parser.parse_args()
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -27,30 +27,38 @@ def run_pipeline(transactions, rules_file, start_row: int = 4, show_progress: bo
         openpyxl Workbook object
     """
     # Load rules
-    print("[1/4] Loading rules...")
+    if show_progress:
+        print("[1/4] Loading rules...")
     loader = RuleLoader(rules_file)
     rules = loader.load()
     classifier = TransactionClassifier(rules)
-    print("    ✅ Rules loaded")
+    if show_progress:
+        print("    ✅ Rules loaded")
 
     # Build exporter
-    print("[2/4] Building exporter...")
+    if show_progress:
+        print("[2/4] Building exporter...")
     exporter = SpreadsheetExporter()
     exporter.build_headers()
-    print("    ✅ Exporter ready")
+    if show_progress:
+        print("    ✅ Exporter ready")
 
     # Process transactions
-    print("[3/4] Classifying and mapping transactions...")
+    if show_progress:
+        print("[3/4] Classifying and mapping transactions...")
     iterator = tqdm(transactions, desc="Processing", unit="tx") if show_progress else transactions
     for idx, tx in enumerate(iterator, start=start_row):
         classification = classifier.classify(tx)
         row = map_transaction_to_row(tx, classification, idx)
         exporter.write_transaction(idx, row)
-    print("    ✅ Transactions classified and mapped")
+    if show_progress:
+        print("    ✅ Transactions classified and mapped")
 
     # Add totals row
-    print("[4/4] Finalizing totals row...")
+    if show_progress:
+        print("[4/4] Finalizing totals row...")
     exporter.finalize_totals_row(start_row, idx) # type: ignore
-    print("    ✅ Totals row complete")
+    if show_progress:
+        print("    ✅ Totals row complete")
 
     return exporter.wb


### PR DESCRIPTION
This pull request adds an option to disable progress bars and verbose status messages during the bookkeeping pipeline execution. The main changes introduce a new command-line argument and update the pipeline to respect this setting.

**CLI improvements:**

* Added a `--no-progress` command-line argument in `project.py` to allow users to disable progress bars and verbose status messages.

**Pipeline behavior updates:**

* Updated the `main()` function in `project.py` to conditionally print progress messages and to pass the `show_progress` flag to the pipeline based on the `--no-progress` argument.
* Modified the `run_pipeline` function in `src/pipeline.py` to wrap all progress messages and the use of `tqdm` progress bars with the `show_progress` flag, so they are only shown when not disabled.… execution