### PR TITLE
tests(project): Add smoke test for main() end-to-end pipeline execution

### DIFF
--- a/tests/test_project_smoke.py
+++ b/tests/test_project_smoke.py
@@ -1,0 +1,37 @@
+import sys
+import json
+import pytest
+from pathlib import Path
+import project
+
+
+def test_main_smoke(tmp_path, monkeypatch):
+    """
+    End-to-end smoke test for project.main().
+    Creates a fake data/{year} with one CSV and a fake rules file,
+    then runs main() with CLI args.
+    """
+
+    year = 2024
+
+    # --- Setup fake environment ---
+    data_dir = tmp_path / "data" / str(year)
+    data_dir.mkdir(parents=True)
+    csv_file = data_dir / "transactions.csv"
+    csv_file.write_text("2024-01-01,Test Transaction,100,,200")
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    rules_file = config_dir / "allocation_rules.json"
+    rules_file.write_text(json.dumps({"_rules": []}))
+
+    # --- Patch working directory and CLI args ---
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["project.py", "--year", str(year), "--rules", str(rules_file)])
+
+    # --- Run main() ---
+    project.main()
+
+    # --- Verify output workbook exists ---
+    output_file = tmp_path / "output" / str(year) / f"bookkeeping_{year}.xlsx"
+    assert output_file.exists()


### PR DESCRIPTION
### ✅ What This Test Does

- Creates a **temporary fake environment:**
  - `data/{year}/transactions.csv` with one row.
  - `config/allocation_rules.json` with a minimal ruleset.
- Patches `sys.argv` to simulate CLI call.
- Calls `project.main()`.
- Asserts that the expected Excel file is created in `output/{year}`.