### PR TITLE
refactor(mapping,export): Retain ignored transactions and flag them f…

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -23,6 +23,7 @@ class SpreadsheetExporter:
         self.ws = self.wb.active # type: ignore
         self.ws.title = "Bookkeeping"
         self.highlight_fill = PatternFill("solid", fgColor="FFFF99")
+        self.ignore_fill = PatternFill("solid", fgColor="D9D9D9")
         self.thin_border = Border(
             top=Side(border_style="thin", color="000000"),
             bottom=Side(border_style="thin", color="000000"),
@@ -68,6 +69,9 @@ class SpreadsheetExporter:
             # Apply highlighting and borders if manual review flag is set
             if transaction.get("highlight"):
                 cell.fill = self.highlight_fill
+            if transaction.get("ignore"):
+                cell.fill = self.ignore_fill
+                    
             cell.border = self.thin_border
 
     def finalize_totals_row(self, start_row: int, end_row: int):

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -55,6 +55,11 @@ def map_transaction_to_row(raw_tx: dict, classification: dict, row_idx: int) -> 
     if classification["transaction_type"] in ["MANUAL_CR", "MANUAL_DR"]:
         row["Notes"] = f"Please, review unclassified transaction: {raw_tx.get('Description')}"
         row["highlight"] = True
+    
+    # Notes column for ignored transactions
+    if classification["transaction_type"] == "IGNORE_TRANSACTION":
+        row["Notes"] = f"Ignored transaction: {raw_tx.get('Description', 'item') + ' -> ' + str(raw_tx.get('Debit') or raw_tx.get('Credit'))}"
+        row["ignore"] = True
 
     # TOTAL column formula will be inserted by exporter (formula_template)
     return row


### PR DESCRIPTION
This pull request adds support for marking and visually distinguishing ignored transactions in the exported spreadsheet. Specifically, it introduces a new fill color for ignored transactions, sets a note for them, and ensures they are styled appropriately in the output.

**Support for ignored transactions:**

* Added a new gray fill style (`ignore_fill`) for ignored transactions in the `__init__` method of `export.py`.
* Updated the `write_transaction` method in `export.py` to apply the gray fill when a transaction is marked as ignored.

**Transaction mapping enhancements:**

* Modified `map_transaction_to_row` in `mapping.py` to set a specific note and an `ignore` flag for transactions classified as `IGNORE_TRANSACTION`.…or audit