### PR TITLE
Add bank profiles contributor guide (Closes #37)

### DIFF
--- a/docs/bank_profiles.md
+++ b/docs/bank_profiles.md
@@ -1,0 +1,149 @@
+# 🏦 Bank Profiles Guide
+
+This guide explains how to add support for new banks and credit cards by creating **profile configs**.  
+Profiles define how statements (PDF or CSV) are parsed and normalized into the unified bookkeeping format.
+
+---
+
+## 📖 Overview
+
+Each bank profile is a JSON file stored in:
+
+`config/bank_profiles/{bank}.json`
+
+Profiles describe:
+- **Sections** in PDF statements (e.g., Purchases, Payments, Interest)
+- **Column mappings** (which field is at which index)
+- **Footer rules** (skip totals, balances)
+- **Optional CSV format rules** (for banks that export CSVs directly)
+
+All profiles are validated against `config/profile_template.json` (JSON schema).
+
+---
+
+## 🛠️ Steps to Add a New Bank Profile
+
+1. **Collect Statement Details**
+   - Layout (single vs two‑column, headers/footers)
+   - Section titles
+   - Column order
+   - Sample rows
+   - Parsing quirks (totals, multi‑line descriptions, negative amounts)
+   - Filename convention
+
+2. **Fill in the Template**
+   - Use `profile_template.json` as a reference.
+   - Define `bank_name`, `sections`, and optional `csv_format`.
+
+3. **Save Config**
+   - Place the new JSON file in `config/bank_profiles/`.
+   - Name it clearly (e.g., `triangle.json`, `cibc.json`, `td_visa.json`).
+
+4. **Validate Config**
+   - Run tests to ensure schema compliance:
+     ```bash
+     pytest -v
+     ```
+   - Loader will raise errors if the config is invalid.
+
+5. **Add Tests**
+   - Create pytest fixtures in `tests/test_pdf_ingest.py`.
+   - Simulate sample tables (PDF) or CSV files.
+   - Assert parsing results (transaction count, field values, amounts).
+
+---
+
+## 📋 Examples
+
+### Triangle MasterCard (`triangle.json`)
+
+```json
+{
+  "bank_name": "Triangle MasterCard",
+  "sections": [
+    {
+      "section_name": "Purchases",
+      "match_text": "Purchases",
+      "columns": {
+        "transaction_date": 0,
+        "posting_date": 1,
+        "description": 2,
+        "amount": 3
+      },
+      "skip_footer_rows": true
+    }
+  ]
+}
+```
+
+### CIBC MasterCard (`cibc.json`)
+
+```json
+{
+  "bank_name": "CIBC Costco MasterCard",
+  "sections": [
+    {
+      "section_name": "Payments",
+      "match_text": "Your payments",
+      "columns": {
+        "transaction_date": 0,
+        "posting_date": 1,
+        "description": 2,
+        "amount": 3
+      },
+      "skip_footer_rows": true
+    }
+  ]
+}
+```
+
+### TD Visa (`td_visa.json`)
+
+```json
+{
+  "bank_name": "TD Emerald Flex Rate Visa",
+  "sections": [
+    {
+      "section_name": "Transactions",
+      "match_text": "TD EMERALD FLEX RATE CARD",
+      "columns": {
+        "transaction_date": 0,
+        "posting_date": 1,
+        "description": 2,
+        "amount": 3
+      },
+      "skip_footer_rows": true
+    }
+  ],
+  "csv_format": {
+    "date_format": "MM/DD/YYYY",
+    "columns": {
+      "transaction_date": 0,
+      "description": 1,
+      "debit": 2,
+      "credit": 3,
+      "balance": 4
+    },
+    "skip_footer_rows": true
+  }
+}
+```
+
+---
+
+## Best Practices
+
+- Always include sample rows in tests to catch quirks.
+- Use `skip_footer_rows` to avoid totals and balances.
+- Normalize amounts: charges positive, payments negative.
+- Keep configs minimal but flexible — only add extra fields if needed (`spend_category`, `annual_interest_rate`).
+- Document quirks in commit messages for future maintainers.
+
+---
+
+## 📌 Next Steps
+
+- Add your new profile JSON.
+- Write pytest fixtures.
+- Commit with a message referencing the issue (e.g., `Closes #42`).
+- Push and open a PR.


### PR DESCRIPTION
This pull request adds a comprehensive guide for creating and managing bank profile configs, which define how statements from various banks and credit cards are parsed and normalized. The documentation covers the process for adding new profiles, validation steps, examples, and best practices, making it easier for developers to extend support for additional financial institutions.

**Documentation: Bank Profile Configs**

* Added `docs/bank_profiles.md` with a step-by-step guide for contributing new bank and credit card profile configs, including instructions for collecting statement details, filling out the template, saving and validating configs, and adding tests.
* Provided example profile JSONs for Triangle MasterCard, CIBC MasterCard, and TD Visa, illustrating how to define sections, column mappings, and CSV format rules.
* Included best practices and next steps to ensure consistency, maintainability, and thorough testing when adding new profiles.